### PR TITLE
Merry as type

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -157,23 +157,27 @@ func ReplaceNativeMessage(e error, msg string) Error {
 // A wrapped merry Error of e is returned. The key value pairs of the targetType is kept and then
 // appended with key value map from the input error. Stack trace of the original input error is maintained.
 func AsType(e error, targetType Error) Error {
-	if e == nil {
-		return nil
-	}
-
 	if targetType == nil {
 		return Wrap(e)
 	}
+	switch e.(type) {
+	case nil:
+		return nil
 
-	output := targetType.Here()
-	output = output.WithValue(stack, Value(e, stack))
+	case *merryErr:
+		output := targetType.Here()
+		output = output.WithValue(stack, Value(e, stack))
 
-	inputMap := Values(e)
-	for k, v := range inputMap {
-		output = output.WithValue(k, v)
+		inputMap := Values(e)
+		for k, v := range inputMap {
+			output = output.WithValue(k, v)
+		}
+		return Append(output, e.Error())
+
+	default:
+		output := targetType.Here()
+		return Append(output, e.Error())
 	}
-
-	return output
 }
 
 // WithValue adds a context an error.  If the key was already set on e,

--- a/errors.go
+++ b/errors.go
@@ -153,18 +153,27 @@ func ReplaceNativeMessage(e error, msg string) Error {
 }
 
 // AsType "casts" an input error as a target merry.Error such that the returned merry Error evaluates
-// to true when operating Is(newErr, targetErr)
-func AsType(i error, targetType Error) Error {
-	target := targetType.(*merryErr)
-	target.err = i
-	target.WithValue(stack, captureStack(1))
-
-	inputMap := Values(i)
-	for k, v := range inputMap {
-		target = target.WithValue(k, v).(*merryErr)
+// to true when operating Is(newErr, targetErr). If e is nil, return nil. If targetType is nil,
+// A wrapped merry Error of e is returned. The key value pairs of the targetType is kept and then
+// appended with key value map from the input error. Stack trace of the original input error is maintained.
+func AsType(e error, targetType Error) Error {
+	if e == nil {
+		return nil
 	}
 
-	return target
+	if targetType == nil {
+		return Wrap(e)
+	}
+
+	output := targetType
+	output = output.WithValue(stack, Value(e, stack))
+
+	inputMap := Values(e)
+	for k, v := range inputMap {
+		output = output.WithValue(k, v)
+	}
+
+	return output
 }
 
 // WithValue adds a context an error.  If the key was already set on e,

--- a/errors.go
+++ b/errors.go
@@ -152,6 +152,21 @@ func ReplaceNativeMessage(e error, msg string) Error {
 	}
 }
 
+// AsType "casts" an input error as a target merry.Error such that the returned merry Error evaluates
+// to true when operating Is(newErr, targetErr)
+func AsType(i error, targetType Error) Error {
+	target := targetType.(*merryErr)
+	target.err = i
+	target.WithValue(stack, captureStack(1))
+
+	inputMap := Values(i)
+	for k, v := range inputMap {
+		target = target.WithValue(k, v).(*merryErr)
+	}
+
+	return target
+}
+
 // WithValue adds a context an error.  If the key was already set on e,
 // the new value will take precedence.
 // If e is nil, returns nil.

--- a/errors.go
+++ b/errors.go
@@ -156,13 +156,13 @@ func ReplaceNativeMessage(e error, msg string) Error {
 // to true when operating Is(newErr, targetErr). If e is nil, return nil. If targetType is nil,
 // A wrapped merry Error of e is returned. The key value pairs of the targetType is kept and then
 // appended with key value map from the input error. Stack trace of the original input error is maintained.
-func AsType(e error, targetType Error) Error {
+func AsType(e error, targetType Error) (Error, bool) {
 	if e == nil {
-		return nil
+		return nil, false
 	}
 
 	if targetType == nil {
-		return Wrap(e)
+		return Wrap(e), false
 	}
 
 	output := targetType.Here()
@@ -173,7 +173,7 @@ func AsType(e error, targetType Error) Error {
 		output = output.WithValue(k, v)
 	}
 
-	return output
+	return output, true
 }
 
 // WithValue adds a context an error.  If the key was already set on e,

--- a/errors.go
+++ b/errors.go
@@ -165,7 +165,7 @@ func AsType(e error, targetType Error) Error {
 		return Wrap(e)
 	}
 
-	output := targetType
+	output := targetType.Here()
 	output = output.WithValue(stack, Value(e, stack))
 
 	inputMap := Values(e)

--- a/errors.go
+++ b/errors.go
@@ -85,6 +85,7 @@ type Error interface {
 	Here() Error
 	WithStackSkipping(skip int) Error
 	WithHTTPCode(code int) Error
+	WithErrorIdentity(errId error) Error
 	fmt.Formatter
 }
 
@@ -149,34 +150,6 @@ func ReplaceNativeMessage(e error, msg string) Error {
 		return wrapped.Prepend(msg)
 	} else {
 		return wrapped.WithValue("error", e.Error()).WithMessage(msg)
-	}
-}
-
-// AsType "casts" an input error as a target merry.Error such that the returned merry Error evaluates
-// to true when operating Is(newErr, targetErr). If e is nil, return nil. If targetType is nil,
-// A wrapped merry Error of e is returned. The key value pairs of the targetType is kept and then
-// appended with key value map from the input error. Stack trace of the original input error is maintained.
-func AsType(e error, targetType Error) (Error, bool) {
-	if targetType == nil {
-		return Wrap(e), false
-	}
-	switch e.(type) {
-	case nil:
-		return nil, false
-
-	case *merryErr:
-		output := targetType.Here()
-		output = output.WithValue(stack, Value(e, stack))
-
-		inputMap := Values(e)
-		for k, v := range inputMap {
-			output = output.WithValue(k, v)
-		}
-		return Append(output, e.Error()), true
-
-	default:
-		output := targetType.Here()
-		return Append(output, e.Error()), true
 	}
 }
 
@@ -378,7 +351,11 @@ func Prependf(e error, format string, args ...interface{}) Error {
 	return WrapSkipping(e, 1).Prependf(format, args...)
 }
 
-// Is checks whether e is equal to or wraps the original, at any depth.
+// Is checks whether e is equal to or wraps the original at any depth.
+// Based on this, Is is modified to also return true if e's identities
+// collections has an error which equals to or wraps the original.
+// Is would search recursively in the error identity tree.
+
 // If e == nil, return false.
 // This is useful if your package uses the common golang pattern of
 // exported error constants.  If your package exports an ErrEOF constant,
@@ -397,28 +374,45 @@ func Prependf(e error, format string, args ...interface{}) Error {
 //
 //     if merry.Is(err, urpack.ErrEOF) {
 //
+
+// We could use errA.WithErrorIdentity(errB) to add errB into errA's
+// error identity slice. Is(errA, errX) would return true if any of the
+// below condition is satisfied:
+// 1. errX is in errA's identity collection tree
+// 2. errX is wrapped by any element in errA's identity collection tree
+//
+// This modification is for error identification and categorization purpose.
+
 func Is(e error, originals ...error) bool {
-	is := func(e, original error) bool {
-		for {
-			if e == original {
-				return true
-			}
-			if e == nil || original == nil {
-				return false
-			}
-			w, ok := e.(*merryErr)
-			if !ok {
-				return false
-			}
-			e = w.err
-		}
-	}
 	for _, o := range originals {
 		if is(e, o) {
 			return true
 		}
 	}
 	return false
+}
+
+func is(e error, original error) bool {
+	for {
+		if e == original {
+			return true
+		}
+		if e == nil || original == nil {
+			return false
+		}
+		w, ok := e.(*merryErr)
+		if !ok {
+			return false
+		}
+		if ids, ok := Value(e, additionalErrorIdentities).([]error); ok {
+			for _, id := range ids {
+				if is(id, original) {
+					return true
+				}
+			}
+		}
+		e = w.err
+	}
 }
 
 // Unwrap returns the innermost underlying error.
@@ -451,10 +445,11 @@ func captureStack(skip int) []uintptr {
 type errorProperty string
 
 const (
-	stack       errorProperty = "stack"
-	message                   = "message"
-	httpCode                  = "http status code"
-	userMessage               = "user message"
+	stack                     errorProperty = "stack"
+	message                                 = "message"
+	httpCode                                = "http status code"
+	userMessage                             = "user message"
+	additionalErrorIdentities               = "additional error identities"
 )
 
 type merryErr struct {
@@ -597,4 +592,13 @@ func (e *merryErr) Prependf(format string, args ...interface{}) Error {
 		return nil
 	}
 	return e.Prepend(fmt.Sprintf(format, args...))
+}
+
+func (e *merryErr) WithErrorIdentity(errId error) Error {
+	var idents []error
+	if i, ok := Value(e, additionalErrorIdentities).([]error); ok {
+		idents = i
+	}
+	idents = append(idents, errId)
+	return e.WithValue(additionalErrorIdentities, idents)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -521,6 +521,13 @@ func TestVerboseDefault(t *testing.T) {
 	assert.Equal(t, "yikes", s)
 }
 
+func TestAsType(t *testing.T) {
+	origin := errors.New("origin")
+	castType := New("castType")
+	newErr := AsType(origin, castType)
+	assert.True(t, Is(newErr, castType))
+}
+
 func TestMerryErr_Error(t *testing.T) {
 	origVerbose := verbose
 	defer func() {

--- a/errors_test.go
+++ b/errors_test.go
@@ -524,8 +524,15 @@ func TestVerboseDefault(t *testing.T) {
 func TestAsType(t *testing.T) {
 	origin := errors.New("origin")
 	castType := New("castType")
-	newErr := AsType(origin, castType)
-	assert.True(t, Is(newErr, castType))
+	newMerryErr := AsType(origin, castType)
+
+	assert.True(t, Is(newMerryErr, castType))
+	assert.Equal(t, newMerryErr.Error(), castType.Error())
+
+	assert.False(t, Is(newMerryErr, origin))
+	assert.NotEqual(t, newMerryErr.Error(), origin.Error())
+
+	assert.Equal(t, Stacktrace(newMerryErr), Stacktrace(origin))
 }
 
 func TestMerryErr_Error(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -522,17 +522,27 @@ func TestVerboseDefault(t *testing.T) {
 }
 
 func TestAsType(t *testing.T) {
-	origin := errors.New("origin")
+	origin := New("origin")
+	originStackTrace := Stacktrace(origin)
+
 	castType := New("castType")
+	castTypeTrace := Stacktrace(castType)
+
 	newMerryErr := AsType(origin, castType)
 
+	// test new merry error is castType
 	assert.True(t, Is(newMerryErr, castType))
 	assert.Equal(t, newMerryErr.Error(), castType.Error())
 
+	// newMerryErr is not equal of original error any more but has the same stack trace as origin
 	assert.False(t, Is(newMerryErr, origin))
 	assert.NotEqual(t, newMerryErr.Error(), origin.Error())
 
-	assert.Equal(t, Stacktrace(newMerryErr), Stacktrace(origin))
+	assert.Equal(t, Stacktrace(newMerryErr), originStackTrace)
+	assert.NotEqual(t, Stacktrace(newMerryErr), castTypeTrace)
+
+	// castType stack trace hasn't been changed
+	assert.Equal(t, Stacktrace(castType), castTypeTrace)
 }
 
 func TestMerryErr_Error(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -528,7 +528,8 @@ func TestAsType(t *testing.T) {
 	castType := New("castType")
 	castTypeTrace := Stacktrace(castType)
 
-	newMerryErr := AsType(origin, castType)
+	newMerryErr, ok := AsType(origin, castType)
+	assert.True(t, ok)
 
 	// test new merry error is castType
 	assert.True(t, Is(newMerryErr, castType))

--- a/errors_test.go
+++ b/errors_test.go
@@ -540,8 +540,8 @@ func TestAsType(t *testing.T) {
 	assert.False(t, Is(newMerryErr, origin))
 
 	// test new error message is <castType error message>: <original error message>
-	assert.Equal(t, newMerryErr.Error(), castType.Error()+": "+origin.Error())
-	assert.NotEqual(t, newMerryErr.Error(), origin.Error())
+	assert.Equal(t, castType.Error()+": "+origin.Error(), newMerryErr.Error())
+	assert.NotEqual(t, origin.Error(), newMerryErr.Error())
 
 	// newMerryErr is not equal of original error any more but has the same stack trace as origin
 	assert.Equal(t, Stacktrace(newMerryErr), originStackTrace)
@@ -552,7 +552,7 @@ func TestAsType(t *testing.T) {
 
 	/*
 	* Test when the original error is Go library error and the castType error is a merry error
-	 */
+	*/
 	libErr := errors.New("Go library error")
 	newMerryErr, ok = AsType(libErr, castType)
 	libErrStackTrace := Stacktrace(libErr)
@@ -563,11 +563,11 @@ func TestAsType(t *testing.T) {
 	assert.True(t, ok)
 
 	// test new error message is <castType error message>: <original error message>
-	assert.Equal(t, newMerryErr.Error(), castType.Error()+": "+libErr.Error())
+	assert.Equal(t, castType.Error()+": "+libErr.Error(), newMerryErr.Error())
 
 	// The original libErr's StackTrace should be empty, but the newMerryErr has its non-empty StackTrace
-	assert.Equal(t, libErrStackTrace, "")
-	assert.NotEqual(t, newMerryErr, "")
+	assert.Equal(t, "", libErrStackTrace)
+	assert.NotEqual(t, "", newMerryErr)
 
 	// castType stack trace hasn't been changed
 	assert.Equal(t, Stacktrace(castType), castTypeTrace)
@@ -586,7 +586,7 @@ func TestAsType(t *testing.T) {
 	assert.Equal(t, Stacktrace(newMerryErr), originStackTrace)
 
 	// newMerryErr has the same error message as origin
-	assert.Equal(t, newMerryErr.Error(), origin.Error())
+	assert.Equal(t, origin.Error(), newMerryErr.Error())
 
 	// the newMerryErr should remain the same type as origin, different from castType
 	assert.True(t, Is(newMerryErr, origin))
@@ -603,14 +603,29 @@ func TestAsType(t *testing.T) {
 	assert.False(t, ok)
 
 	// newMerryErr is nil
-	assert.Equal(t, nilOrigin, nil)
-	assert.Equal(t, newMerryErr, nil)
+	assert.Equal(t, nil, nilOrigin)
+	assert.Equal(t, nil, newMerryErr)
 
 	// newMerryErr and nilOrigin are both nil, thus Is(newMerryErr, nilOrigin) return true
 	// But if only one of the two params passed in Is() is nil, it returns false
 	assert.True(t, Is(newMerryErr, nilOrigin))
 	assert.False(t, Is(newMerryErr, castType))
 	assert.False(t, ok)
+
+	/*
+	* Test if input key-value pairs have priority over castType
+	*/
+	origin = WithValue(origin, "foo","bar1")
+	castType = WithValue(castType,"foo", "bar2")
+	newMerryErr, ok = AsType(origin, castType)
+
+	// test new merry error is castType, instead of origin's type
+	assert.True(t, Is(newMerryErr, castType))
+	assert.False(t, Is(newMerryErr, libErr))
+	assert.True(t, ok)
+
+	// Value(newMerryErr, "foo") should be the same as origin
+	assert.Equal(t, "bar1", Value(newMerryErr, "foo"))
 
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -525,7 +525,7 @@ func TestAsType(t *testing.T) {
 
 	/*
 	* Test when the original error and the castType error are all merry errors
-	*/
+	 */
 	origin := New("origin")
 	originStackTrace := Stacktrace(origin)
 
@@ -540,7 +540,7 @@ func TestAsType(t *testing.T) {
 	assert.False(t, Is(newMerryErr, origin))
 
 	// test new error message is <castType error message>: <original error message>
-	assert.Equal(t, newMerryErr.Error(), castType.Error() + ": " + origin.Error())
+	assert.Equal(t, newMerryErr.Error(), castType.Error()+": "+origin.Error())
 	assert.NotEqual(t, newMerryErr.Error(), origin.Error())
 
 	// newMerryErr is not equal of original error any more but has the same stack trace as origin
@@ -552,7 +552,7 @@ func TestAsType(t *testing.T) {
 
 	/*
 	* Test when the original error is Go library error and the castType error is a merry error
-	*/
+	 */
 	libErr := errors.New("Go library error")
 	newMerryErr, ok = AsType(libErr, castType)
 	libErrStackTrace := Stacktrace(libErr)
@@ -563,7 +563,7 @@ func TestAsType(t *testing.T) {
 	assert.True(t, ok)
 
 	// test new error message is <castType error message>: <original error message>
-	assert.Equal(t, newMerryErr.Error(), castType.Error() + ": " + libErr.Error())
+	assert.Equal(t, newMerryErr.Error(), castType.Error()+": "+libErr.Error())
 
 	// The original libErr's StackTrace should be empty, but the newMerryErr has its non-empty StackTrace
 	assert.Equal(t, libErrStackTrace, "")
@@ -575,7 +575,7 @@ func TestAsType(t *testing.T) {
 	/*
 	* Test when the castType error is nil:
 	* - return wrap(origin), false
-	*/
+	 */
 	var nilCastType Error
 
 	newMerryErr, ok = AsType(origin, nilCastType)
@@ -595,7 +595,7 @@ func TestAsType(t *testing.T) {
 	/*
 	* Test when the original error is nil:
 	* - return nil, false
-	*/
+	 */
 
 	var nilOrigin Error
 	newMerryErr, ok = AsType(nilOrigin, castType)


### PR DESCRIPTION
# Summary
* Append the original error message into the casted new error
* Modify the return types to (Error, bool) to indicate whether casting succeeds or not
* Modify AsType() to deal with non-merry original errors
* Add tests for nil input, non-merry original error, key-value pair assertion

# Story
* https://myhelix.atlassian.net/browse/HPLT-37